### PR TITLE
Improve parsing of parameters

### DIFF
--- a/parse-mime.lisp
+++ b/parse-mime.lisp
@@ -185,11 +185,13 @@ returns all comments contained within that string"
   "Takes a string of parameters and returns a list of keyword/value
 parameter pairs"
   (if (register-groups-bind
-       (parm-name parm-value rest)
-       (";\\s*(.*?)=\"?([^;\"\\s]*)\"?[\\s]*(;?.*)" parm-string)
+       (parm-name parm-value pv2 rest)
+       (";\\s*(.*?)=(?:([^()<>@,;:\\\\\"/\\]\\[?=\\s]+)|(?:\"((?:[^\\\\\"]|(?:\\\\.))*)\")(;.*))" parm-string)
        
        (setq parm-string rest)
-       (setq parms (cons (list (ensure-keyword parm-name) parm-value)
+       (setq parms (cons (list (ensure-keyword parm-name)
+			       (or parm-value
+				   (regex-replace-all '(:SEQUENCE #\\ (:REGISTER :EVERYTHING)) pv2 '(0))))
 			 parms)))
   
       (extract-parms parm-string parms)


### PR DESCRIPTION
Previously this would only accept a very limited form of quoted
parameters.  This has two problems:

1. Parameters need not be quoted if they are a valid token
2. Quoted parameters with e.g. " " or ";" in their name would be parsed
   incorrectly

Fix:

Create two bindings:
  - one of valid tokens (i.e. everything without:
    `()<>@,;:\"/[]?=` or whitspace, or control characters`)
  - One for quoted strings; per RFC822, a backslash is an escape for the
    literal character following the backslash.

Example:

  (CL-MIME::EXTRACT-PARMS "; foo=\"A \\\"b\"; bar=baz")
   => ((:BAR "baz") (:FOO "A \"b"))