### PR TITLE
Fixed parsing of header parameters surrounded by ".

### DIFF
--- a/cl-mime-test.asd
+++ b/cl-mime-test.asd
@@ -1,0 +1,10 @@
+(defsystem :cl-mime-test
+  :name "MIME-TEST"
+  :author "Alexander Artemenko <svetlyak.40wt@gmail.com>"
+  :depends-on ("cl-mime" "rove")
+  :serial t
+  :components ((:module "t"
+                :components ((:file "package")
+                             (:file "parse-mime"))))
+  :perform (test-op (op c)
+                    (symbol-call '#:rove '#:run c)))

--- a/cl-mime.asd
+++ b/cl-mime.asd
@@ -32,11 +32,11 @@
   :maintainer "Robert Marlow <bobstopper@bobturf.org>"
   :depends-on (:cl-ppcre :cl-base64 :cl-qprint)
   :serial t
-  :components
-  ((:file "package")
-   (:file "utilities")
-   (:file "classes")
-   (:file "headers")
-   (:file "encoding")
-   (:file "parse-mime")
-   (:file "print-mime")))
+  :components ((:file "package")
+               (:file "utilities")
+               (:file "classes")
+               (:file "headers")
+               (:file "encoding")
+               (:file "parse-mime")
+               (:file "print-mime"))
+  :in-order-to ((test-op (test-op "cl-mime-test"))))

--- a/t/package.lisp
+++ b/t/package.lisp
@@ -1,0 +1,4 @@
+(defpackage #:cl-mime-test
+  (:use #:cl
+        #:rove))
+(in-package cl-mime-test)

--- a/t/parse-mime.lisp
+++ b/t/parse-mime.lisp
@@ -1,0 +1,20 @@
+(in-package cl-mime-test)
+
+
+(deftest header-raw-params-test
+  (ok (equal (mime::header-raw-params
+              '(:CONTENT-TYPE
+                . "multipart/alternative; boundary=\"b1_b50de8f53d68a7437a6359aef2dbb344\""))
+             "; boundary=\"b1_b50de8f53d68a7437a6359aef2dbb344\"")))
+
+
+(deftest header-params-test
+  (ok (equal (mime::header-parms
+              '(:content-type
+                . "multipart/alternative; boundary=\"b1_b50de8f53d68a7437a6359aef2dbb344\""))
+             '((:boundary "b1_b50de8f53d68a7437a6359aef2dbb344"))))
+  
+  (ok (equal (mime::header-parms
+              '(:content-type . "multipart/alternative; boundary=\"Apple-Mail=_CDCD9DE7-5FDE-4605-AA7C-01981ECF3587\"; foo=bar"))
+             '((:foo "bar")
+               (:boundary "Apple-Mail=_CDCD9DE7-5FDE-4605-AA7C-01981ECF3587")))))


### PR DESCRIPTION
Previously headers like:

    multipart/alternative; boundary="b1_b50de8f53d68a7437a6359aef2dbb344"

were parsed correctly only if the line ended by ;

Also now cl-mime has a test suite!